### PR TITLE
Composable controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ let frames = oddio::FramesSource::from(oddio::Frames::from_slice(sample_rate, &f
 let mut handle = remote.play(oddio::Spatial::new(frames, position, velocity));
 
 // When position/velocity changes:
-handle.set_motion(position, velocity);
+handle.control::<oddio::Spatial<_>, _>().set_motion(position, velocity);
 ```

--- a/examples/realtime.rs
+++ b/examples/realtime.rs
@@ -54,7 +54,7 @@ fn main() {
         .unwrap();
     stream.play().unwrap();
 
-    let mut source = remote.play(source);
+    let source = remote.play(source);
 
     let start = Instant::now();
 
@@ -67,7 +67,7 @@ fn main() {
         // This is in principle a no-op because the velocity isn't changing, but due to imprecise
         // sleep times and the fact that the audio thread runs at unaligned intervals means that the
         // this would produce glitches if not for smoothing done by `Spatial`.
-        source.set_motion(
+        source.control::<oddio::Spatial<_>, _>().set_motion(
             [-speed + speed * dt.as_secs_f32(), 10.0, 0.0].into(),
             [speed, 0.0, 0.0].into(),
         );

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,96 @@
+use std::marker::PhantomData;
+
+use crate::Handle;
+
+/// A [`Source`](crate::Source) which transforms another source
+pub trait Filter {
+    /// Type of source transformed by this filter
+    type Inner;
+
+    /// Access the inner source
+    fn inner(&self) -> &Self::Inner;
+}
+
+impl<T> Handle<T> {
+    /// Get the control for source `S` in a chain of sources
+    ///
+    /// `Index` can usually be inferred.
+    ///
+    /// # Example
+    /// ```
+    /// # use oddio::*;
+    /// fn quiet(source: &Handle<Spatial<Gain<FramesSource<Sample>>>>) {
+    ///     source.control::<Gain<_>, _>().set_gain(0.5);
+    /// }
+    /// ```
+    pub fn control<S, Index>(&self) -> Control<'_, S>
+    where
+        T: FilterHaving<S, Index>,
+    {
+        unsafe { Control(&(*self.get()).get()) }
+    }
+}
+
+/// Control for a specific element of a chain of sources
+///
+/// Obtained from [`Handle::control`].
+pub struct Control<'a, T>(&'a T);
+
+impl<T> Control<'_, T> {
+    /// Access a potentially `!Sync` source
+    ///
+    /// Building block for safe abstractions over nontrivial shared memory.
+    pub fn get(&self) -> *const T {
+        self.0
+    }
+}
+
+impl<T: Sync> AsRef<T> for Control<'_, T> {
+    fn as_ref(&self) -> &T {
+        self.0
+    }
+}
+
+/// Filter chains that contain a `T` at any position
+///
+/// `Index` is [`Here`] or [`There`], and can generally be inferred.
+pub trait FilterHaving<T, Index> {
+    /// Get the `T` element of a filter chain
+    fn get(&self) -> &T;
+}
+
+/// `Index` value for `FilterHaving` representing the first filter in the chain
+pub struct Here(());
+
+/// `Index` value for `FilterHaving` representing the filter at position `T+1`
+pub struct There<T>(PhantomData<T>);
+
+impl<T> FilterHaving<T, Here> for T {
+    fn get(&self) -> &T {
+        self
+    }
+}
+
+impl<T: Filter, U, I> FilterHaving<U, There<I>> for T
+where
+    T::Inner: FilterHaving<U, I>,
+{
+    fn get(&self) -> &U {
+        self.inner().get()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn _foo<A, B, C>(x: &A)
+    where
+        A: Filter<Inner = B>,
+        B: Filter<Inner = C>,
+    {
+        let _: &A = x.get();
+        let _: &B = x.get();
+        let _: &C = x.get();
+    }
+}

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use crate::{Control, Frame, Source, StridedMut};
+use crate::{Control, Filter, Frame, Source, StridedMut};
 
 /// Scales amplitude by a dynamically-adjustable factor
 pub struct Gain<T: ?Sized> {
@@ -42,7 +42,19 @@ where
     }
 }
 
-impl<T> Control<Gain<T>> {
+impl<T> Filter for Gain<T> {
+    type Inner = T;
+    fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> Control<'_, Gain<T>> {
+    /// Get the current gain
+    pub fn gain(&self) -> f32 {
+        unsafe { f32::from_bits((*self.get()).gain.load(Ordering::Relaxed)) }
+    }
+
     /// Adjust the gain
     pub fn set_gain(&mut self, factor: f32) {
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! let mut handle = remote.play(oddio::Spatial::new(frames, position, velocity));
 //!
 //! // When position/velocity changes:
-//! handle.set_motion(position, velocity);
+//! handle.control::<oddio::Spatial<_>, _>().set_motion(position, velocity);
 //! ```
 //!
 //! Key primitives:
@@ -28,6 +28,7 @@
 
 #![warn(missing_docs)]
 
+mod filter;
 mod frame;
 mod frames;
 mod gain;
@@ -40,6 +41,7 @@ mod stream;
 pub mod strided;
 mod swap;
 
+pub use filter::*;
 pub use frame::Frame;
 pub use frames::*;
 pub use gain::Gain;

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -5,7 +5,7 @@ use crate::{
     math::{add, dot, mix, norm, scale, sub},
     split_stereo,
     swap::Swap,
-    Control, Sample, Source, StridedMut,
+    Control, Filter, Sample, Source, StridedMut,
 };
 
 /// Places a mono source at an adjustable position and velocity wrt. the listener
@@ -115,7 +115,14 @@ where
     }
 }
 
-impl<T> Control<Spatial<T>> {
+impl<T> Filter for Spatial<T> {
+    type Inner = T;
+    fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> Control<'_, Spatial<T>> {
     /// Update the position and velocity of the source
     pub fn set_motion(&mut self, position: mint::Point3<f32>, velocity: mint::Vector3<f32>) {
         unsafe {


### PR DESCRIPTION
Fixes #10. Ended up without a truly distinct notion of filters to avoid overly restricting source transformations.