### PR TITLE
Forbid random access in Signal

### DIFF
--- a/examples/offline.rs
+++ b/examples/offline.rs
@@ -14,11 +14,12 @@ fn main() {
             (t * 500.0 * 2.0 * std::f32::consts::PI).sin() * 80.0
         }),
     );
-    let (mut scene_handle, scene) = oddio::spatial();
+    let (mut scene_handle, scene) = oddio::spatial(RATE, 0.1);
     scene_handle.play(
         oddio::FramesSignal::from(boop),
         [-SPEED, 10.0, 0.0].into(),
         [SPEED, 0.0, 0.0].into(),
+        1000.0,
     );
 
     let mut frames = vec![[0.0; 2]; (RATE * DURATION_SECS) as usize];

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -1,8 +1,8 @@
 use std::cell::Cell;
 
-use crate::{Filter, Frame, Signal};
+use crate::{Filter, Frame, Seek, Signal};
 
-/// Loops a signal
+/// Loops a [`Seek`]able signal
 pub struct Cycle<T: ?Sized> {
     duration: f32,
     cursor: Cell<f32>,
@@ -21,31 +21,24 @@ impl<T> Cycle<T> {
     }
 }
 
-impl<T: Signal> Signal for Cycle<T>
+impl<T: Signal + Seek> Signal for Cycle<T>
 where
     T::Frame: Frame,
 {
     type Frame = T::Frame;
 
-    fn sample(&self, mut offset: f32, sample_length: f32, mut out: &mut [T::Frame]) {
-        offset = (offset + self.cursor.get()).rem_euclid(self.duration);
+    fn sample(&self, interval: f32, mut out: &mut [T::Frame]) {
         while !out.is_empty() {
-            let seconds = self.duration - offset;
-            let samples = seconds / sample_length;
-            let end = (1 + samples as usize).min(out.len());
-            self.inner.sample(offset, sample_length, &mut out[..end]);
-            offset = (1.0 - samples.fract()) * sample_length;
-            out = &mut out[end..];
+            let seconds = self.duration - self.cursor.get();
+            let samples = 1 + (seconds / interval) as usize;
+            let n = samples.min(out.len());
+            self.inner.sample(interval, &mut out[..n]);
+            self.cursor.set(self.cursor.get() + interval * n as f32);
+            if self.cursor.get() > self.duration {
+                self.seek_to(self.cursor.get());
+            }
+            out = &mut out[n..];
         }
-    }
-
-    fn advance(&self, dt: f32) {
-        self.cursor
-            .set((self.cursor.get() + dt).rem_euclid(self.duration));
-    }
-
-    fn remaining(&self) -> f32 {
-        f32::INFINITY
     }
 }
 
@@ -56,34 +49,68 @@ impl<T> Filter for Cycle<T> {
     }
 }
 
+impl<T: Seek> Seek for Cycle<T> {
+    fn seek_to(&self, t: f32) {
+        let t = t.rem_euclid(self.duration);
+        self.inner.seek_to(t);
+        self.cursor.set(t);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;
 
     use super::*;
 
-    #[test]
-    fn wrap() {
-        // Logs the time of every sample
-        struct LoggedSignal(RefCell<Vec<f32>>);
+    // Logs the time of every sample
+    struct LoggedSignal {
+        times: RefCell<Vec<f32>>,
+        t: Cell<f32>,
+    }
 
-        impl Signal for LoggedSignal {
-            type Frame = f32;
-            fn sample(&self, offset: f32, interval: f32, out: &mut [f32]) {
-                for i in 0..out.len() {
-                    self.0.borrow_mut().push(offset + i as f32 * interval);
-                }
+    impl Signal for LoggedSignal {
+        type Frame = f32;
+        fn sample(&self, interval: f32, out: &mut [f32]) {
+            for i in 0..out.len() {
+                self.times
+                    .borrow_mut()
+                    .push(self.t.get() + i as f32 * interval);
             }
-
-            fn advance(&self, _: f32) {}
-
-            fn remaining(&self) -> f32 {
-                f32::INFINITY
-            }
+            self.t.set(self.t.get() + interval * out.len() as f32);
         }
+    }
 
-        let s = Cycle::new(LoggedSignal(RefCell::new(Vec::new())), 1.25);
-        s.sample(0.0, 1.0, &mut [0.0; 5]);
-        assert_eq!(s.inner.0.borrow()[..], [0.0, 1.0, 0.75, 0.5, 0.25]);
+    impl Seek for LoggedSignal {
+        fn seek_to(&self, t: f32) {
+            self.t.set(t);
+        }
+    }
+
+    #[test]
+    fn wrap_single() {
+        let s = Cycle::new(
+            LoggedSignal {
+                t: Cell::new(0.0),
+                times: RefCell::new(Vec::new()),
+            },
+            1.25,
+        );
+        s.sample(1.0, &mut [0.0; 5]);
+        assert_eq!(s.inner.times.borrow()[..], [0.0, 1.0, 0.75, 0.5, 0.25]);
+    }
+
+    #[test]
+    fn wrap_multi() {
+        let s = Cycle::new(
+            LoggedSignal {
+                t: Cell::new(0.0),
+                times: RefCell::new(Vec::new()),
+            },
+            2.5,
+        );
+        s.sample(1.0, &mut [0.0; 2]);
+        s.sample(1.0, &mut [0.0; 2]);
+        assert_eq!(s.inner.times.borrow()[..], [0.0, 1.0, 2.0, 0.5]);
     }
 }

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -1,10 +1,16 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::{
+    cell::Cell,
+    sync::atomic::{AtomicU32, Ordering},
+};
 
 use crate::{frame, Controlled, Filter, Frame, Seek, Signal};
 
 /// Scales amplitude by a dynamically-adjustable factor
 pub struct Gain<T: ?Sized> {
-    gain: AtomicU32,
+    shared: AtomicU32,
+    prev_gain: Cell<f32>,
+    next_gain: Cell<f32>,
+    time_since_changed: Cell<f32>,
     inner: T,
 }
 
@@ -12,9 +18,18 @@ impl<T> Gain<T> {
     /// Apply dynamic gain to `signal`
     pub fn new(signal: T) -> Self {
         Self {
-            gain: AtomicU32::new(1.0f32.to_bits()),
+            shared: AtomicU32::new(1.0f32.to_bits()),
+            prev_gain: Cell::new(1.0),
+            next_gain: Cell::new(1.0),
+            time_since_changed: Cell::new(1.0),
             inner: signal,
         }
+    }
+
+    fn gain(&self) -> f32 {
+        let diff = self.next_gain.get() - self.prev_gain.get();
+        let progress = ((self.time_since_changed.get()) / SMOOTHING_PERIOD).min(1.0);
+        self.prev_gain.get() + progress * diff
     }
 }
 
@@ -24,12 +39,19 @@ where
 {
     type Frame = T::Frame;
 
+    #[allow(clippy::float_cmp)]
     fn sample(&self, interval: f32, out: &mut [T::Frame]) {
         self.inner.sample(interval, out);
-        // TODO: Blend from the previous value
-        let gain = f32::from_bits(self.gain.load(Ordering::Relaxed));
+        let shared = f32::from_bits(self.shared.load(Ordering::Relaxed));
+        if self.next_gain.get() != shared {
+            self.prev_gain.set(self.gain());
+            self.next_gain.set(shared);
+            self.time_since_changed.set(0.0);
+        }
         for x in out {
-            *x = frame::scale(x, gain);
+            *x = frame::scale(x, self.gain());
+            self.time_since_changed
+                .set(self.time_since_changed.get() + interval);
         }
     }
 
@@ -64,11 +86,44 @@ unsafe impl<'a, T: 'a> Controlled<'a> for Gain<T> {
 impl<'a, T> GainControl<'a, T> {
     /// Get the current gain
     pub fn gain(&self) -> f32 {
-        f32::from_bits(self.0.gain.load(Ordering::Relaxed))
+        f32::from_bits(self.0.shared.load(Ordering::Relaxed))
     }
 
     /// Adjust the gain
     pub fn set_gain(&mut self, factor: f32) {
-        self.0.gain.store(factor.to_bits(), Ordering::Relaxed);
+        self.0.shared.store(factor.to_bits(), Ordering::Relaxed);
+    }
+}
+
+/// Number of seconds over which to smooth a change in gain
+const SMOOTHING_PERIOD: f32 = 0.1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::Sample;
+
+    struct Const;
+
+    impl Signal for Const {
+        type Frame = Sample;
+
+        fn sample(&self, _: f32, out: &mut [Sample]) {
+            for x in out {
+                *x = 1.0;
+            }
+        }
+    }
+
+    #[test]
+    fn smoothing() {
+        let s = Gain::new(Const);
+        let mut buf = [0.0; 6];
+        GainControl(&s).set_gain(5.0);
+        s.sample(0.025, &mut buf);
+        assert_eq!(buf, [1.0, 2.0, 3.0, 4.0, 5.0, 5.0]);
+        s.sample(0.025, &mut buf);
+        assert_eq!(buf, [5.0; 6]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //! Lightweight game audio
 //!
 //! ```no_run
-//! let (mut scene_handle, scene) = oddio::spatial();
+//! # let sample_rate = 44100;
+//! let (mut scene_handle, scene) = oddio::spatial(sample_rate, 0.1);
 //!
 //! // In audio callback:
 //! # let data = &mut [][..];
@@ -15,7 +16,7 @@
 //! # let position = [0.0, 0.0, 0.0].into();
 //! # let velocity = [0.0, 0.0, 0.0].into();
 //! let frames = oddio::FramesSignal::from(oddio::Frames::from_slice(sample_rate, &frames));
-//! let mut handle = scene_handle.play(frames, position, velocity);
+//! let mut handle = scene_handle.play(frames, position, velocity, 1000.0);
 //!
 //! // When position/velocity changes:
 //! handle.control::<oddio::Spatial<_>, _>().set_motion(position, velocity);
@@ -39,6 +40,7 @@ mod handle;
 mod math;
 mod mixer;
 mod reinhard;
+mod ring;
 mod set;
 mod signal;
 mod sine;
@@ -69,11 +71,10 @@ pub type Sample = f32;
 
 /// Populate `out` with frames from `signal` at `sample_rate`
 ///
-/// Convenience wrapper around the [`Signal`] interface.
+/// Convenience wrapper for [`Signal::sample`].
 pub fn run<S: Signal>(signal: &S, sample_rate: u32, out: &mut [S::Frame]) {
-    let sample_len = 1.0 / sample_rate as f32;
-    signal.sample(0.0, sample_len, out);
-    signal.advance(sample_len * out.len() as f32);
+    let interval = 1.0 / sample_rate as f32;
+    signal.sample(interval, out);
 }
 
 /// Convert a slice of interleaved stereo data into a slice of stereo frames

--- a/src/reinhard.rs
+++ b/src/reinhard.rs
@@ -23,17 +23,13 @@ where
 {
     type Frame = T::Frame;
 
-    fn sample(&self, offset: f32, sample_length: f32, out: &mut [T::Frame]) {
-        self.0.sample(offset, sample_length, out);
+    fn sample(&self, interval: f32, out: &mut [T::Frame]) {
+        self.0.sample(interval, out);
         for x in out {
             for channel in x.channels_mut() {
                 *channel /= 1.0 + channel.abs();
             }
         }
-    }
-
-    fn advance(&self, dt: f32) {
-        self.0.advance(dt);
     }
 
     fn remaining(&self) -> f32 {

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,0 +1,112 @@
+use crate::{frame, Sample, Signal};
+
+pub struct Ring {
+    buffer: Box<[Sample]>,
+    write: f32,
+}
+
+impl Ring {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buffer: vec![0.0; capacity].into(),
+            write: 0.0,
+        }
+    }
+
+    /// Fill buffer from `signal`
+    pub fn write<S: Signal<Frame = Sample> + ?Sized>(&mut self, signal: &S, rate: u32, dt: f32) {
+        debug_assert!(
+            dt * rate as f32 <= self.buffer.len() as f32,
+            "output range exceeds capacity"
+        );
+        let end = (self.write + dt * rate as f32) % self.buffer.len() as f32;
+
+        let start_idx = self.write.ceil() as usize;
+        let end_idx = end.ceil() as usize;
+        let interval = 1.0 / rate as f32;
+        if end_idx > start_idx {
+            signal.sample(interval, &mut self.buffer[start_idx..end_idx]);
+        } else {
+            signal.sample(interval, &mut self.buffer[start_idx..]);
+            signal.sample(interval, &mut self.buffer[..end_idx]);
+        }
+
+        self.write = end;
+    }
+
+    /// Advance write cursor by `dt` given internal sample rate `rate`, as if writing a `Signal`
+    /// that produces only zeroes
+    pub fn delay(&mut self, rate: u32, dt: f32) {
+        self.write = (self.write + rate as f32 * dt) % self.buffer.len() as f32;
+    }
+
+    /// Get the recorded signal at a certain sample, relative to the *write* cursor. `t` must be
+    /// negative.
+    pub fn sample(&self, rate: u32, t: f32) -> f32 {
+        debug_assert!(t < 0.0, "samples must lie in the past");
+        debug_assert!(
+            ((t * rate as f32).abs().ceil() as usize) < self.buffer.len(),
+            "samples must lie less than a buffer period in the past"
+        );
+        let s = (self.write + t * rate as f32).rem_euclid(self.buffer.len() as f32);
+        let x0 = s.trunc() as usize;
+        let fract = s.fract() as f32;
+        let x1 = x0 + 1;
+        let a = self.get(x0);
+        let b = self.get(x1);
+        frame::lerp(&a, &b, fract)
+    }
+
+    fn get(&self, sample: usize) -> f32 {
+        if sample >= self.buffer.len() {
+            return 0.0;
+        }
+        self.buffer[sample]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    struct TimeSignal(Cell<f32>);
+
+    impl Signal for TimeSignal {
+        type Frame = Sample;
+        fn sample(&self, interval: f32, out: &mut [Sample]) {
+            for x in out {
+                let t = self.0.get();
+                *x = t as f32;
+                self.0.set(t + interval);
+            }
+        }
+    }
+
+    #[test]
+    fn fill() {
+        let mut r = Ring::new(4);
+        let s = TimeSignal(Cell::new(1.0));
+
+        r.write(&s, 1, 1.0);
+        assert_eq!(r.write, 1.0);
+        assert_eq!(r.buffer[..], [1.0, 0.0, 0.0, 0.0]);
+
+        r.write(&s, 1, 2.0);
+        assert_eq!(r.write, 3.0);
+        assert_eq!(r.buffer[..], [1.0, 2.0, 3.0, 0.0]);
+    }
+
+    #[test]
+    fn wrap() {
+        let mut r = Ring::new(4);
+        let s = TimeSignal(Cell::new(1.0));
+
+        r.write(&s, 1, 3.0);
+        assert_eq!(r.buffer[..], [1.0, 2.0, 3.0, 0.0]);
+
+        r.write(&s, 1, 3.0);
+        assert_eq!(r.buffer[..], [5.0, 6.0, 3.0, 4.0]);
+    }
+}

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,6 +1,6 @@
 use crate::{flatten_stereo, Gain, Sample};
 
-/// An audio signal with a cursor
+/// An audio signal
 ///
 /// This interface is intended for use only from the code actually generating an audio signal for
 /// output. For example, in a real-time application, `Signal`s will typically be owned by the
@@ -15,29 +15,18 @@ pub trait Signal {
     /// Type of frames yielded by `get`, e.g. `[Sample; 2]` for stereo.
     type Frame;
 
-    /// Sample every `sample_interval` seconds starting at `offset` from the cursor.
+    /// Sample every `interval` seconds starting at `offset` from the cursor.
     ///
-    /// `sample_interval` and `offset` may be negative.
-    fn sample(&self, offset: f32, sample_interval: f32, out: &mut [Self::Frame]);
-
-    /// Advance time by `dt` seconds
-    ///
-    /// Future calls to `sample` will behave as if `dt` were added to `offset`, potentially with
-    /// extra precision. Typically invoked after a batch of samples have been taken, with the total
-    /// period covered by those samples.
-    ///
-    /// Note that this method takes `&self`, even though side-effects are expected. Implementers are
-    /// expected to rely on interior mutability. This allows `Signal`s to be accessed while playing
-    /// via [`Handle::control`](crate::Handle::control), permitting real-time control with
-    /// e.g. atomics.
-    fn advance(&self, dt: f32);
+    /// `interval` and `offset` may be negative.
+    fn sample(&self, interval: f32, out: &mut [Self::Frame]);
 
     /// Seconds until data runs out
     ///
-    /// May be infinite for unbounded signals, or negative after advancing past the end. May change
-    /// independently of calls to `advance` for signals with dynamic underlying data such as
-    /// real-time streams.
-    fn remaining(&self) -> f32;
+    /// May be infinite for unbounded signals, or negative after advancing past the end.
+    #[inline]
+    fn remaining(&self) -> f32 {
+        f32::INFINITY
+    }
 
     //
     // Helpers
@@ -66,21 +55,29 @@ pub struct MonoToStereo<T>(pub T);
 impl<T: Signal<Frame = Sample>> Signal for MonoToStereo<T> {
     type Frame = [Sample; 2];
 
-    fn sample(&self, dt: f32, offset: f32, out: &mut [[Sample; 2]]) {
+    fn sample(&self, interval: f32, out: &mut [[Sample; 2]]) {
         let n = out.len();
         let buf = flatten_stereo(out);
-        self.0.sample(dt, offset, &mut buf[..n]);
+        self.0.sample(interval, &mut buf[..n]);
         for i in (0..buf.len()).rev() {
             buf[i] = buf[i / 2];
         }
     }
 
-    fn advance(&self, dt: f32) {
-        self.0.advance(dt);
-    }
-
     fn remaining(&self) -> f32 {
         self.0.remaining()
+    }
+}
+
+/// A [`Signal`] that can skip around freely in time
+pub trait Seek {
+    /// Set the next [`Signal::sample`] call to start at `t`
+    fn seek_to(&self, t: f32);
+}
+
+impl<T: Seek> Seek for MonoToStereo<T> {
+    fn seek_to(&self, t: f32) {
+        self.0.seek_to(t);
     }
 }
 
@@ -94,18 +91,12 @@ mod tests {
 
     impl Signal for CountingSignal {
         type Frame = Sample;
-        fn sample(&self, _: f32, _: f32, out: &mut [Sample]) {
+        fn sample(&self, _: f32, out: &mut [Sample]) {
             for x in out {
                 let i = self.0.get();
                 *x = i as f32;
                 self.0.set(i + 1);
             }
-        }
-
-        fn advance(&self, _: f32) {}
-
-        fn remaining(&self) -> f32 {
-            f32::INFINITY
         }
     }
 
@@ -113,7 +104,7 @@ mod tests {
     fn mono_to_stereo() {
         let signal = CountingSignal(Cell::new(0)).into_stereo();
         let mut buf = [[0.0; 2]; 4];
-        signal.sample(1.0, 0.0, (&mut buf[..]).into());
+        signal.sample(1.0, (&mut buf[..]).into());
         assert_eq!(buf, [[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [3.0, 3.0]]);
     }
 }

--- a/src/sine.rs
+++ b/src/sine.rs
@@ -1,10 +1,9 @@
 use std::{cell::Cell, f32::consts::TAU};
 
-use crate::{Sample, Signal};
+use crate::{Sample, Seek, Signal};
 
 /// A trivial [`Signal`] that produces a sine wave of a particular frequency, forever
 pub struct Sine {
-    /// Normalized units, i.e. [0, 1)
     phase: Cell<f32>,
     /// Radians per second
     frequency: f32,
@@ -18,7 +17,7 @@ impl Sine {
     /// may produce weird interference effects if their phases align.
     pub fn new(phase: f32, frequency_hz: f32) -> Self {
         Self {
-            phase: Cell::new(phase / TAU),
+            phase: Cell::new(phase),
             frequency: frequency_hz * TAU,
         }
     }
@@ -27,20 +26,19 @@ impl Sine {
 impl Signal for Sine {
     type Frame = Sample;
 
-    fn sample(&self, offset: f32, sample_length: f32, out: &mut [Sample]) {
-        let start = self.phase.get() + offset;
+    fn sample(&self, interval: f32, out: &mut [Sample]) {
         for (i, x) in out.iter_mut().enumerate() {
-            let t = start + sample_length * i as f32;
-            *x = (t * self.frequency).sin();
+            let t = interval * i as f32;
+            *x = (t * self.frequency + self.phase.get()).sin();
         }
+        self.seek_to(interval * out.len() as f32);
     }
+}
 
-    fn advance(&self, dt: f32) {
-        // Advance time, but wrap into 0-1 for numerical stability no matter how long we play for
-        self.phase.set((self.phase.get() + dt).fract());
-    }
-
-    fn remaining(&self) -> f32 {
-        f32::INFINITY
+impl Seek for Sine {
+    fn seek_to(&self, t: f32) {
+        // Advance time, but wrap for numerical stability no matter how long we play for
+        self.phase
+            .set((self.phase.get() + t * self.frequency) % TAU);
     }
 }


### PR DESCRIPTION
This forces spatialization to implement propagation delay with
internal buffering, but makes it possible to guarantee glitch-free
audio when dynamic parameters change without massively complicating
Signal and implementations thereof.

Fixes #33.