### PR TITLE
Remove adapter methods

### DIFF
--- a/examples/realtime.rs
+++ b/examples/realtime.rs
@@ -59,7 +59,6 @@ fn main() {
 
     // We can also add filters around our `FramesSignal` to make our sound more controllable.
     // A common one is `Gain`, which lets us modulate the gain of the `Signal` (how loud it is)
-    // We also could make this with `.with_gain` if `oddio::Signal` is brought into scope.
     let gain = oddio::Gain::new(basic_signal);
 
     // The type given out from `.play` reflects the controls we placed in it.


### PR DESCRIPTION
Maintaining these for every filter would be tedious and make externally implemented filters feel second-class.