### PR TITLE
Add control for FramesSignal.

### DIFF
--- a/src/frames.rs
+++ b/src/frames.rs
@@ -192,15 +192,11 @@ impl<'a, T> FramesSignalControl<'a, T> {
     ///
     /// This number may be negative if the starting time was negative,
     /// and it may be longer than the duration of the sample as well.
+    /// 
+    /// Right now, we don't support a method to *set* the playback_position,
+    /// as naively setting this variable causes audible distortions.
     pub fn playback_position(&self) -> f64 {
         self.0.t.get()
-    }
-
-    /// Sets the current playback position in seconds.
-    ///
-    /// This number may be negative.
-    pub fn set_playback_position(&mut self, value: f64) {
-        self.0.t.set(value);
     }
 }
 

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -192,7 +192,7 @@ impl<'a, T> FramesSignalControl<'a, T> {
     ///
     /// This number may be negative if the starting time was negative,
     /// and it may be longer than the duration of the sample as well.
-    /// 
+    ///
     /// Right now, we don't support a method to *set* the playback_position,
     /// as naively setting this variable causes audible distortions.
     pub fn playback_position(&self) -> f64 {


### PR DESCRIPTION
Some thoughts:

1. **Most importantly, I have a 'set_playback_position' but it's not very good.** Right now, it results in an audible "glitch" in my experimenting, and I suspect you'll have opinions on that. I'd be more than happy with removing that and having the rest of the PR accepted. All the other points below this are, in increasing order, bike shedding.
2. I abstracted over the encoded f64, which you might rather do inline yourself. It just made it so I didn't need to touch the sampling code, which I didn't want to touch if I didn't have to. I think this abstraction is fine, and the entire repo uses Relaxed ordering, so I think it's valid, but if you'd like to me split it out, I absolutely can!
3. Speaking of which, most of the API of oddio is in f32s, but FramesSignal worked in f64s previously. I assume we'll still want to be doing that, right? I feel like users can choose to put it in f32 if they want. Alternatively, the getter can return an f32 on its own.
4. Finally, `FramesSignalController` is kind of a long unwieldy name? It's more or less in line with the rest of the codebase though, so I just gave that it that beauty of a name. If you have any inspiration, I have no attachment to it.

Thanks for all your hard work! I appreciate the code review I expect I will undergo from this :))