### PR TITLE
Make the runtime of Frames public.

### DIFF
--- a/src/frames.rs
+++ b/src/frames.rs
@@ -85,6 +85,11 @@ impl<T> Frames<T> {
         self.rate as u32
     }
 
+    /// The runtime in seconds
+    pub fn runtime(&self) -> f64 {
+        self.samples.len() as f64 / self.rate
+    }
+
     /// Interpolate a frame for position `s`
     ///
     /// Note that `s` is in samples, not seconds. Whole numbers are always an exact sample, and


### PR DESCRIPTION
This PR extends the API for Frames and makes the length and the runtime public. I need access to it for my custom "Cycle" implementation where I can toggle if I want to repeat a SFX and if I want to include a pause for this (for example the sound of  foot steps).

Since english is not my mother tongue, "runtime" may not be the right name.