### PR TITLE
rename the outputted wavs with the example name

### DIFF
--- a/examples/adapt.rs
+++ b/examples/adapt.rs
@@ -23,7 +23,7 @@ fn main() {
         bits_per_sample: 16,
         sample_format: hound::SampleFormat::Int,
     };
-    let mut writer = hound::WavWriter::create("a.wav", spec).unwrap();
+    let mut writer = hound::WavWriter::create("adapt.wav", spec).unwrap();
 
     let mut drive = || {
         for _ in 0..(RATE * DURATION_SECS / BLOCK_SIZE as u32) {

--- a/examples/offline.rs
+++ b/examples/offline.rs
@@ -29,7 +29,7 @@ fn main() {
         bits_per_sample: 16,
         sample_format: hound::SampleFormat::Int,
     };
-    let mut writer = hound::WavWriter::create("a.wav", spec).unwrap();
+    let mut writer = hound::WavWriter::create("offline.wav", spec).unwrap();
 
     for _ in 0..(RATE * DURATION_SECS / BLOCK_SIZE as u32) {
         let mut block = [[0.0; 2]; BLOCK_SIZE];


### PR DESCRIPTION
This is a small ergonomic change. Right now a couple of examples both output an `a.wav` file. This PR renames the wav file with the name of the example in order to make them easier to identificate and avoid overwriting.