### PR TITLE
Mark oddio as no_std Fixes #64

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           command: test
 
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-targets
+          args: --all-features
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,12 +32,12 @@ jobs:
 
       - uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --all-features
+          command: test
 
       - uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: build
+          args: --all-features
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,11 @@ jobs:
 
       - uses: actions-rs/cargo@v1
         with:
+          command: build
+          args: --all-targets
+
+      - uses: actions-rs/cargo@v1
+        with:
           command: test
 
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,14 @@ categories = ["multimedia::audio", "game-development"]
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+no_std = ["libm"]
+
 [dependencies]
 mint = "0.5.5"
+libm = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 cpal = "0.13.1"
 hound = "3.4"
+ 

--- a/src/adapt.rs
+++ b/src/adapt.rs
@@ -1,6 +1,6 @@
 use core::cell::Cell;
 
-use crate::{Filter, Frame, Signal};
+use crate::{math::Float, Filter, Frame, Signal};
 
 /// Smoothly adjusts gain over time to keep average (RMS) signal level within a target range
 ///

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 use core::cell::Cell;
 
-use crate::{frame, Frame, Frames, Seek, Signal};
+use crate::{frame, math::Float, Frame, Frames, Seek, Signal};
 
 /// Loops [`Frames`] end-to-end to construct a repeating signal
 pub struct Cycle<T> {

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -1,4 +1,4 @@
-use crate::alloc::{alloc, sync::Arc};
+use crate::alloc::{alloc, boxed::Box, sync::Arc};
 use core::{
     cell::Cell,
     mem,
@@ -7,7 +7,7 @@ use core::{
     sync::atomic::{AtomicIsize, Ordering},
 };
 
-use crate::{frame, Controlled, Frame, Seek, Signal};
+use crate::{frame, math::Float, Controlled, Frame, Seek, Signal};
 
 /// A sequence of static audio frames at a particular sample rate
 ///

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -3,7 +3,7 @@ use core::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
-use crate::{frame, Controlled, Filter, Frame, Signal, Smoothed};
+use crate::{frame, math::Float, Controlled, Filter, Frame, Signal, Smoothed};
 
 /// Amplifies a signal
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,13 @@
 //! - [`Handle`] allows control of a signal while it's playing, from a mixer or [`split`]
 //! - [`run`] writes frames from a [`Signal`] into an output buffer
 
+#![allow(unused_imports)]
 #![warn(missing_docs)]
+#![no_std]
 
 extern crate alloc;
+#[cfg(not(feature = "no_std"))]
+extern crate std;
 
 mod adapt;
 mod constant;

--- a/src/math/libm.rs
+++ b/src/math/libm.rs
@@ -1,0 +1,145 @@
+use crate::math::Float;
+
+impl Float for f32 {
+    fn abs(self) -> Self {
+        libm::fabsf(self)
+    }
+
+    fn sqrt(self) -> Self {
+        libm::sqrtf(self)
+    }
+
+    fn exp(self) -> Self {
+        libm::expf(self)
+    }
+
+    fn ceil(self) -> Self {
+        libm::ceilf(self)
+    }
+
+    fn trunc(self) -> Self {
+        libm::truncf(self)
+    }
+
+    fn fract(self) -> Self {
+        self - self.trunc()
+    }
+
+    fn log10(self) -> Self {
+        libm::log10f(self)
+    }
+
+    fn powf(self, n: Self) -> Self {
+        libm::powf(self, n)
+    }
+
+    fn powi(mut self, mut rhs: i32) -> Self {
+        let mut r = 1.0;
+        let invert = if rhs < 0 {
+            rhs *= -1;
+            true
+        } else {
+            false
+        };
+        loop {
+            if rhs % 2 == 1 {
+                r *= self;
+            }
+            rhs /= 2;
+            if rhs == 0 {
+                break;
+            }
+            self *= self;
+        }
+        if invert {
+            1.0 / r
+        } else {
+            r
+        }
+    }
+
+    fn sin(self) -> Self {
+        libm::sinf(self)
+    }
+
+    fn rem_euclid(self, rhs: Self) -> Self {
+        let r = self % rhs;
+        if r < 0.0 {
+            r + rhs.abs()
+        } else {
+            r
+        }
+    }
+}
+
+impl Float for f64 {
+    fn abs(self) -> Self {
+        libm::fabs(self)
+    }
+
+    fn sqrt(self) -> Self {
+        libm::sqrt(self)
+    }
+
+    fn exp(self) -> Self {
+        libm::exp(self)
+    }
+
+    fn ceil(self) -> Self {
+        libm::ceil(self)
+    }
+
+    fn trunc(self) -> Self {
+        libm::trunc(self)
+    }
+
+    fn fract(self) -> Self {
+        self - self.trunc()
+    }
+
+    fn log10(self) -> Self {
+        libm::log10(self)
+    }
+
+    fn powf(self, n: Self) -> Self {
+        libm::pow(self, n)
+    }
+
+    fn powi(mut self, mut rhs: i32) -> Self {
+        let mut r = 1.0;
+        let invert = if rhs < 0 {
+            rhs *= -1;
+            true
+        } else {
+            false
+        };
+        loop {
+            if rhs % 2 == 1 {
+                r *= self;
+            }
+            rhs /= 2;
+            if rhs == 0 {
+                break;
+            }
+            self *= self;
+        }
+        if invert {
+            1.0 / r
+        } else {
+            r
+        }
+    }
+
+    fn sin(self) -> Self {
+        libm::sin(self)
+    }
+
+    fn rem_euclid(self, rhs: Self) -> Self {
+        let r = self % rhs;
+        if r < 0.0 {
+            r + rhs.abs()
+        } else {
+            r
+        }
+    }
+}

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,3 +1,33 @@
+#[cfg(not(feature = "no_std"))]
+mod std;
+
+#[cfg(feature = "no_std")]
+mod libm;
+
+pub(crate) trait Float {
+    fn abs(self) -> Self;
+
+    fn sqrt(self) -> Self;
+
+    fn exp(self) -> Self;
+
+    fn ceil(self) -> Self;
+
+    fn trunc(self) -> Self;
+
+    fn fract(self) -> Self;
+
+    fn log10(self) -> Self;
+
+    fn powf(self, n: Self) -> Self;
+
+    fn powi(self, n: i32) -> Self;
+
+    fn sin(self) -> Self;
+
+    fn rem_euclid(self, rhs: Self) -> Self;
+}
+
 pub fn norm(x: mint::Vector3<f32>) -> f32 {
     x.as_ref().iter().map(|&x| x.powi(2)).sum::<f32>().sqrt()
 }

--- a/src/math/std.rs
+++ b/src/math/std.rs
@@ -1,0 +1,93 @@
+use crate::math::Float;
+
+impl Float for f32 {
+    fn abs(self) -> Self {
+        Self::abs(self)
+    }
+
+    fn sqrt(self) -> Self {
+        Self::sqrt(self)
+    }
+
+    fn exp(self) -> Self {
+        Self::exp(self)
+    }
+
+    fn ceil(self) -> Self {
+        Self::ceil(self)
+    }
+
+    fn trunc(self) -> Self {
+        Self::trunc(self)
+    }
+
+    fn fract(self) -> Self {
+        Self::fract(self)
+    }
+
+    fn log10(self) -> Self {
+        Self::log10(self)
+    }
+
+    fn powf(self, n: Self) -> Self {
+        Self::powf(self, n)
+    }
+
+    fn powi(self, n: i32) -> Self {
+        Self::powi(self, n)
+    }
+
+    fn sin(self) -> Self {
+        Self::sin(self)
+    }
+
+    fn rem_euclid(self, rhs: Self) -> Self {
+        Self::rem_euclid(self, rhs)
+    }
+}
+
+impl Float for f64 {
+    fn abs(self) -> Self {
+        Self::abs(self)
+    }
+
+    fn sqrt(self) -> Self {
+        Self::sqrt(self)
+    }
+
+    fn exp(self) -> Self {
+        Self::exp(self)
+    }
+
+    fn ceil(self) -> Self {
+        Self::ceil(self)
+    }
+
+    fn trunc(self) -> Self {
+        Self::trunc(self)
+    }
+
+    fn fract(self) -> Self {
+        Self::fract(self)
+    }
+
+    fn log10(self) -> Self {
+        Self::log10(self)
+    }
+
+    fn powf(self, n: Self) -> Self {
+        Self::powf(self, n)
+    }
+
+    fn powi(self, n: i32) -> Self {
+        Self::powi(self, n)
+    }
+
+    fn sin(self) -> Self {
+        Self::sin(self)
+    }
+
+    fn rem_euclid(self, rhs: Self) -> Self {
+        Self::rem_euclid(self, rhs)
+    }
+}

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -1,4 +1,4 @@
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc, vec};
 use core::cell::RefCell;
 
 use crate::{frame, set, Controlled, Frame, Handle, Set, SetHandle, Signal, Stop};

--- a/src/reinhard.rs
+++ b/src/reinhard.rs
@@ -1,4 +1,4 @@
-use crate::{Filter, Frame, Seek, Signal};
+use crate::{math::Float, Filter, Frame, Seek, Signal};
 
 /// Smoothly maps a signal of any range into (-1, 1)
 ///

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,4 +1,5 @@
-use crate::{frame, Sample, Signal};
+use crate::{frame, math::Float, Sample, Signal};
+use alloc::{boxed::Box, vec};
 
 pub struct Ring {
     buffer: Box<[Sample]>,

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,4 @@
-use alloc::collections::vec_deque::VecDeque;
+use alloc::{collections::vec_deque::VecDeque, vec::Vec};
 use core::{cell::UnsafeCell, mem, ops::Deref};
 
 use crate::spsc;

--- a/src/sine.rs
+++ b/src/sine.rs
@@ -1,6 +1,6 @@
 use core::{cell::Cell, f32::consts::TAU};
 
-use crate::{Sample, Seek, Signal};
+use crate::{math::Float, Sample, Seek, Signal};
 
 /// A trivial [`Signal`] that produces a sine wave of a particular frequency, forever
 pub struct Sine {

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -5,7 +5,7 @@ use core::{
 };
 
 use crate::{
-    math::{add, dot, invert_quat, mix, norm, rotate, scale, sub},
+    math::{add, dot, invert_quat, mix, norm, rotate, scale, sub, Float},
     ring::Ring,
     set::{set, Set, SetHandle},
     swap::Swap,

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -1,4 +1,4 @@
-use crate::alloc::{alloc, sync::Arc};
+use crate::alloc::{alloc, boxed::Box, sync::Arc};
 use core::{
     cell::UnsafeCell,
     fmt, mem,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -2,7 +2,7 @@
 
 use core::cell::{Cell, RefCell};
 
-use crate::{frame, spsc, Controlled, Frame, Signal};
+use crate::{frame, math::Float, spsc, Controlled, Frame, Signal};
 
 /// Dynamic audio from an external source
 pub struct Stream<T> {
@@ -127,6 +127,7 @@ impl<'a, T> StreamControl<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     fn assert_out(stream: &Stream<f32>, expected: &[f32]) {
         let mut output = vec![0.0; expected.len()];


### PR DESCRIPTION
This is kind of ugly with libm. It's probably fine enough to just be soft no_std by not taking a direct dependency on std (the first commit). This PR commits to `#![no_std]` with all the caveats.