### PR TITLE
Alternative no_std Oddio implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 mint = "0.5.5"
+num-traits = { version = "0.2", default-features = false, features = ["libm"]}
 
 [dev-dependencies]
 cpal = "0.13.1"

--- a/src/adapt.rs
+++ b/src/adapt.rs
@@ -1,4 +1,4 @@
-use std::cell::Cell;
+use core::cell::Cell;
 
 use crate::{Filter, Frame, Signal};
 

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -1,4 +1,5 @@
-use std::{cell::Cell, sync::Arc};
+use alloc::sync::Arc;
+use core::cell::Cell;
 
 use crate::{frame, Frame, Frames, Signal};
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,5 @@
-use std::{marker::PhantomData, sync::Arc};
+use alloc::sync::Arc;
+use core::marker::PhantomData;
 
 /// Handle for manipulating a signal owned elsewhere
 ///

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -49,11 +49,11 @@ impl Frame for Sample {
     const ZERO: Sample = 0.0;
 
     fn channels(&self) -> &[Sample] {
-        std::slice::from_ref(self)
+        core::slice::from_ref(self)
     }
 
     fn channels_mut(&mut self) -> &mut [Sample] {
-        std::slice::from_mut(self)
+        core::slice::from_mut(self)
     }
 }
 

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -1,11 +1,9 @@
-use std::{
-    alloc, mem,
+use crate::alloc::{alloc, boxed::Box, sync::Arc};
+use core::{
+    mem,
     ops::{Deref, DerefMut},
     ptr,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use crate::{frame, Controlled, Frame, Signal};

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     cell::RefCell,
     sync::atomic::{AtomicU32, Ordering},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,10 @@
 //! - [`run`] writes frames from a [`Signal`] into an output buffer
 
 #![warn(missing_docs)]
+#![no_std]
+
+extern crate alloc;
+extern crate num_traits;
 
 mod adapt;
 mod constant;
@@ -94,13 +98,13 @@ pub fn run<S: Signal + ?Sized>(signal: &S, sample_rate: u32, out: &mut [S::Frame
 /// The [`Handle`] can be used to control the signal concurrent with the [`SplitSignal`] being
 /// played
 pub fn split<S: Signal>(signal: S) -> (Handle<S>, SplitSignal<S>) {
-    let signal = std::sync::Arc::new(signal);
+    let signal = alloc::sync::Arc::new(signal);
     let handle = unsafe { Handle::from_arc(signal.clone()) };
     (handle, SplitSignal(signal))
 }
 
 /// A concurrently controlled [`Signal`]
-pub struct SplitSignal<S: ?Sized>(std::sync::Arc<S>);
+pub struct SplitSignal<S: ?Sized>(alloc::sync::Arc<S>);
 
 impl<S> Signal for SplitSignal<S>
 where
@@ -124,9 +128,9 @@ unsafe impl<S: ?Sized> Send for SplitSignal<S> {}
 ///
 /// Useful for adapting output buffers obtained externally.
 pub fn frame_stereo(xs: &mut [Sample]) -> &mut [[Sample; 2]] {
-    unsafe { std::slice::from_raw_parts_mut(xs.as_mut_ptr() as _, xs.len() / 2) }
+    unsafe { core::slice::from_raw_parts_mut(xs.as_mut_ptr() as _, xs.len() / 2) }
 }
 
 fn flatten_stereo(xs: &mut [[Sample; 2]]) -> &mut [Sample] {
-    unsafe { std::slice::from_raw_parts_mut(xs.as_mut_ptr() as _, xs.len() * 2) }
+    unsafe { core::slice::from_raw_parts_mut(xs.as_mut_ptr() as _, xs.len() * 2) }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -64,7 +64,7 @@ pub fn rotate(rot: &mint::Quaternion<f32>, p: &mint::Point3<f32>) -> mint::Point
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::f32::consts::PI;
+    use core::f32::consts::PI;
 
     #[test]
     fn rotate_x() {

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -1,4 +1,5 @@
-use std::{cell::RefCell, sync::Arc};
+use alloc::{boxed::Box, sync::Arc, vec};
+use core::cell::RefCell;
 
 use crate::{frame, set, Controlled, Frame, Handle, Set, SetHandle, Signal, Stop};
 

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,4 +1,5 @@
 use crate::{frame, Sample, Signal};
+use alloc::{boxed::Box, vec};
 
 pub struct Ring {
     buffer: Box<[Sample]>,
@@ -67,7 +68,7 @@ impl Ring {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
+    use core::cell::Cell;
 
     use super::*;
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,5 @@
-use std::{cell::UnsafeCell, collections::VecDeque, mem, ops::Deref};
+use crate::alloc::{collections::VecDeque, vec::Vec};
+use core::{cell::UnsafeCell, mem, ops::Deref};
 
 use crate::spsc;
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -76,7 +76,7 @@ impl<T: ?Sized> Filter for MonoToStereo<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
+    use core::cell::Cell;
 
     use super::*;
 

--- a/src/sine.rs
+++ b/src/sine.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, f32::consts::TAU};
+use core::{cell::Cell, f32::consts::TAU};
 
 use crate::{Sample, Signal};
 

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -1,7 +1,7 @@
-use std::{
+use alloc::sync::Arc;
+use core::{
     cell::RefCell,
     ops::{Index, IndexMut},
-    sync::Arc,
 };
 
 use crate::{

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::{Controlled, Filter, Frame, Signal};
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -1,14 +1,11 @@
-use std::{
-    alloc,
+use crate::alloc::{alloc, boxed::Box, sync::Arc};
+use core::{
     cell::UnsafeCell,
     fmt, mem,
     mem::MaybeUninit,
     ops::Index,
     ptr, slice,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {

--- a/src/stop.rs
+++ b/src/stop.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::{Controlled, Filter, Signal};
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,6 @@
 //! Streaming audio support
 
-use std::cell::{Cell, RefCell};
+use core::cell::{Cell, RefCell};
 
 use crate::{frame, spsc, Controlled, Frame, Signal};
 
@@ -126,6 +126,8 @@ impl<'a, T> StreamControl<'a, T> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
 
     fn assert_out(stream: &Stream<f32>, expected: &[f32]) {

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     cell::{Cell, UnsafeCell},
     sync::atomic::{AtomicUsize, Ordering},
 };


### PR DESCRIPTION
Does the exact same thing as #65 , but use `num-traits` as a base instead of directly using `libm`