### PR TITLE
FramesSignal::sample optimizations

### DIFF
--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -37,7 +37,7 @@ impl<T: Frame + Copy> Signal for Cycle<T> {
             } else if x < self.frames.len() {
                 (self.frames[x], self.frames[0])
             } else {
-                offset = (x - self.frames.len()) as f32;
+                offset = (x - self.frames.len()) as f32 + fract;
                 base = 0;
                 let x = unsafe { offset.to_int_unchecked::<usize>() };
                 (self.frames[x], self.frames[x + 1])
@@ -83,5 +83,24 @@ mod tests {
         s.sample(1.0, &mut buf[..2]);
         s.sample(1.0, &mut buf[2..]);
         assert_eq!(buf, [1.0, 2.0, 3.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn wrap_fract() {
+        let s = Cycle::new(Frames::from_slice(1, FRAMES));
+        let mut buf = [0.0; 8];
+        s.sample(0.5, &mut buf[..2]);
+        s.sample(0.5, &mut buf[2..]);
+        assert_eq!(buf, [1.0, 1.5, 2.0, 2.5, 3.0, 2.0, 1.0, 1.5]);
+    }
+
+    #[test]
+    fn wrap_fract_offset() {
+        let s = Cycle::new(Frames::from_slice(1, FRAMES));
+        s.seek(0.25);
+        let mut buf = [0.0; 7];
+        s.sample(0.5, &mut buf[..2]);
+        s.sample(0.5, &mut buf[2..]);
+        assert_eq!(buf, [1.25, 1.75, 2.25, 2.75, 2.5, 1.5, 1.25]);
     }
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -12,6 +12,7 @@ pub trait Frame {
     fn channels_mut(&mut self) -> &mut [Sample];
 }
 
+#[inline(always)]
 fn map<T: Frame>(x: &T, mut f: impl FnMut(Sample) -> Sample) -> T {
     let mut out = T::ZERO;
     for (&x, o) in x.channels().iter().zip(out.channels_mut()) {
@@ -20,6 +21,7 @@ fn map<T: Frame>(x: &T, mut f: impl FnMut(Sample) -> Sample) -> T {
     out
 }
 
+#[inline(always)]
 fn bimap<T: Frame>(x: &T, y: &T, mut f: impl FnMut(Sample, Sample) -> Sample) -> T {
     let mut out = T::ZERO;
     for ((&x, &y), o) in x
@@ -33,14 +35,17 @@ fn bimap<T: Frame>(x: &T, y: &T, mut f: impl FnMut(Sample, Sample) -> Sample) ->
     out
 }
 
+#[inline(always)]
 pub(crate) fn lerp<T: Frame>(a: &T, b: &T, t: f32) -> T {
     bimap(a, b, |a, b| a + t * (b - a))
 }
 
+#[inline(always)]
 pub(crate) fn mix<T: Frame>(a: &T, b: &T) -> T {
     bimap(a, b, |a, b| a + b)
 }
 
+#[inline(always)]
 pub(crate) fn scale<T: Frame>(x: &T, factor: f32) -> T {
     map(x, |x| x * factor)
 }
@@ -48,10 +53,12 @@ pub(crate) fn scale<T: Frame>(x: &T, factor: f32) -> T {
 impl Frame for Sample {
     const ZERO: Sample = 0.0;
 
+    #[inline(always)]
     fn channels(&self) -> &[Sample] {
         core::slice::from_ref(self)
     }
 
+    #[inline(always)]
     fn channels_mut(&mut self) -> &mut [Sample] {
         core::slice::from_mut(self)
     }
@@ -60,10 +67,12 @@ impl Frame for Sample {
 impl<const N: usize> Frame for [Sample; N] {
     const ZERO: Self = [0.0; N];
 
+    #[inline(always)]
     fn channels(&self) -> &[Sample] {
         self.as_ref()
     }
 
+    #[inline(always)]
     fn channels_mut(&mut self) -> &mut [Sample] {
         self.as_mut()
     }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -12,7 +12,7 @@ pub trait Frame {
     fn channels_mut(&mut self) -> &mut [Sample];
 }
 
-#[inline(always)]
+#[inline]
 fn map<T: Frame>(x: &T, mut f: impl FnMut(Sample) -> Sample) -> T {
     let mut out = T::ZERO;
     for (&x, o) in x.channels().iter().zip(out.channels_mut()) {
@@ -21,7 +21,7 @@ fn map<T: Frame>(x: &T, mut f: impl FnMut(Sample) -> Sample) -> T {
     out
 }
 
-#[inline(always)]
+#[inline]
 fn bimap<T: Frame>(x: &T, y: &T, mut f: impl FnMut(Sample, Sample) -> Sample) -> T {
     let mut out = T::ZERO;
     for ((&x, &y), o) in x
@@ -35,17 +35,17 @@ fn bimap<T: Frame>(x: &T, y: &T, mut f: impl FnMut(Sample, Sample) -> Sample) ->
     out
 }
 
-#[inline(always)]
+#[inline]
 pub(crate) fn lerp<T: Frame>(a: &T, b: &T, t: f32) -> T {
     bimap(a, b, |a, b| a + t * (b - a))
 }
 
-#[inline(always)]
+#[inline]
 pub(crate) fn mix<T: Frame>(a: &T, b: &T) -> T {
     bimap(a, b, |a, b| a + b)
 }
 
-#[inline(always)]
+#[inline]
 pub(crate) fn scale<T: Frame>(x: &T, factor: f32) -> T {
     map(x, |x| x * factor)
 }
@@ -53,12 +53,12 @@ pub(crate) fn scale<T: Frame>(x: &T, factor: f32) -> T {
 impl Frame for Sample {
     const ZERO: Sample = 0.0;
 
-    #[inline(always)]
+    #[inline]
     fn channels(&self) -> &[Sample] {
         core::slice::from_ref(self)
     }
 
-    #[inline(always)]
+    #[inline]
     fn channels_mut(&mut self) -> &mut [Sample] {
         core::slice::from_mut(self)
     }
@@ -67,12 +67,12 @@ impl Frame for Sample {
 impl<const N: usize> Frame for [Sample; N] {
     const ZERO: Self = [0.0; N];
 
-    #[inline(always)]
+    #[inline]
     fn channels(&self) -> &[Sample] {
         self.as_ref()
     }
 
-    #[inline(always)]
+    #[inline]
     fn channels_mut(&mut self) -> &mut [Sample] {
         self.as_mut()
     }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -175,9 +175,9 @@ impl<T: Frame + Copy> Signal for FramesSignal<T> {
         let base = s0.trunc() as isize;
         let mut offset = s0.fract() as f32;
         for o in out.iter_mut() {
-            let trunc = offset.trunc();
-            let (a, b) = self.data.get_pair(base + trunc as isize);
-            let fract = offset - trunc;
+            let trunc = unsafe { offset.to_int_unchecked::<isize>() };
+            let (a, b) = self.data.get_pair(base + trunc);
+            let fract = offset - trunc as f32;
             *o = frame::lerp(&a, &b, fract);
             offset += ds;
         }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -93,7 +93,7 @@ impl<T> Frames<T> {
     ///
     /// Note that `s` is in samples, not seconds. Whole numbers are always an exact sample, and
     /// out-of-range positions yield 0.
-    #[inline(always)]
+    #[inline]
     pub fn interpolate(&self, s: f64) -> T
     where
         T: Frame + Copy,
@@ -104,7 +104,7 @@ impl<T> Frames<T> {
         frame::lerp(&a, &b, fract)
     }
 
-    #[inline(always)]
+    #[inline]
     fn get_pair(&self, sample: isize) -> (T, T)
     where
         T: Frame + Copy,

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -173,7 +173,7 @@ impl<T: Frame + Copy> Signal for FramesSignal<T> {
         let s0 = self.t.get() * self.data.rate;
         let ds = interval * self.data.rate as f32;
         let base = s0 as isize;
-        let mut offset = s0.fract() as f32;
+        let mut offset = (s0 - base as f64) as f32;
         for o in out.iter_mut() {
             let trunc = unsafe { offset.to_int_unchecked::<isize>() };
             let (a, b) = self.data.get_pair(base + trunc);

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -118,12 +118,10 @@ impl<T> Frames<T> {
             } else {
                 (T::ZERO, T::ZERO)
             }
+        } else if sample < -1 {
+            (T::ZERO, T::ZERO)
         } else {
-            if sample < -1 {
-                (T::ZERO, T::ZERO)
-            } else {
-                (T::ZERO, self.samples[0])
-            }
+            (T::ZERO, self.samples[0])
         }
     }
 }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -93,6 +93,7 @@ impl<T> Frames<T> {
     ///
     /// Note that `s` is in samples, not seconds. Whole numbers are always an exact sample, and
     /// out-of-range positions yield 0.
+    #[inline(always)]
     pub fn interpolate(&self, s: f64) -> T
     where
         T: Frame + Copy,
@@ -105,6 +106,7 @@ impl<T> Frames<T> {
         frame::lerp(&a, &b, fract)
     }
 
+    #[inline(always)]
     fn get(&self, sample: isize) -> T
     where
         T: Frame + Copy,

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -98,8 +98,8 @@ impl<T> Frames<T> {
     where
         T: Frame + Copy,
     {
-        let x0 = s.trunc() as isize;
-        let fract = s.fract() as f32;
+        let x0 = s as isize;
+        let fract = (s - x0 as f64) as f32;
         let (a, b) = self.get_pair(x0);
         frame::lerp(&a, &b, fract)
     }
@@ -172,7 +172,7 @@ impl<T: Frame + Copy> Signal for FramesSignal<T> {
     fn sample(&self, interval: f32, out: &mut [T]) {
         let s0 = self.t.get() * self.data.rate;
         let ds = interval * self.data.rate as f32;
-        let base = s0.trunc() as isize;
+        let base = s0 as isize;
         let mut offset = s0.fract() as f32;
         for o in out.iter_mut() {
             let trunc = unsafe { offset.to_int_unchecked::<isize>() };

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -100,25 +100,31 @@ impl<T> Frames<T> {
     {
         let x0 = s.trunc() as isize;
         let fract = s.fract() as f32;
-        let x1 = x0 + 1;
-        let a = self.get(x0);
-        let b = self.get(x1);
+        let (a, b) = self.get_pair(x0);
         frame::lerp(&a, &b, fract)
     }
 
     #[inline(always)]
-    fn get(&self, sample: isize) -> T
+    fn get_pair(&self, sample: isize) -> (T, T)
     where
         T: Frame + Copy,
     {
-        if sample < 0 {
-            return T::ZERO;
+        if sample >= 0 {
+            let sample = sample as usize;
+            if sample < self.samples.len() - 1 {
+                (self.samples[sample], self.samples[sample + 1])
+            } else if sample < self.samples.len() {
+                (self.samples[sample], T::ZERO)
+            } else {
+                (T::ZERO, T::ZERO)
+            }
+        } else {
+            if sample < -1 {
+                (T::ZERO, T::ZERO)
+            } else {
+                (T::ZERO, self.samples[0])
+            }
         }
-        let sample = sample as usize;
-        if sample >= self.samples.len() {
-            return T::ZERO;
-        }
-        self.samples[sample]
     }
 }
 


### PR DESCRIPTION
Hi! While benchmarking various audio libraries I've noticed that the current implementation of `FramesSignal::sample` (which currently consumes most of the time in `oddio::run`) has less than optimal performance. This PR contains substantial performance with minor code changes:
1. Added a few missing `#[inlines]`: the largest perf improvements of 30%-40%
2. Replaced two calls to `Frames::get` with one call `Frames::get_pair`: reduces the number of checks in the fast path (removes a few conditional expressions and allows the optimizer to remove the bound checks), improvement of 5-10%
3. (The least obvious improvement) Replaced f64 with f32 in the main loop in `FramesSignal::sample` by splitting the f64 position into the isize base and the f32 offset. The loss of precision looks extremely minor given that the `sample` should be called frequently with small buffer sizes (a few hundreds milliseconds at most). This removes the f64 -> f32 conversion in inner loop in `Frames::interpolate` and gives another 5-10% perf improvement.
4. (Controversial improvement) Replaced `f32::trunc` with `f32.to_int_unchecked::<isize>`. This massively (30+%) improves performance with default x86-64 builds due to `trunc` being a libm call before x86-64-v2 (SSE4.1). The performance on aarch64 is unchanged. While there are probably almost no pre-SSE4.1 CPUs in active use, I feel that the default experience (running `cargo build` without any flags) matters. The use of unsafe `to_int_unchecked` slightly improves the performance, but it can be changed to `f32 as isize` with minor performance hit.

All the improvements have been tested using three CPUs: Intel Core (MacBook Pro 16 Late 2019), AMD EPYC 7003 (Hetzner Cloud) and Snapdragon 888 (Samsung S21FE).

Similar optimizations (2 and 4 in particular) can be applied to `Stream::sample` as well.

Profile before the changes:
<img width="979" alt="Screenshot 2022-08-07 at 23 15 03" src="https://user-images.githubusercontent.com/149705/183648531-85aacfa7-5f4f-4207-a7b0-13cfb390dccf.png">
