### PR TITLE
SpatialScene::play_buffered optimizations

### DIFF
--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -57,12 +57,8 @@ impl<T: Frame + Copy> Signal for Cycle<T> {
 impl<T: Frame + Copy> Seek for Cycle<T> {
     fn seek(&self, seconds: f32) {
         let s = (self.cursor.get() + f64::from(seconds) * self.frames.rate() as f64)
-            % self.frames.len() as f64;
-        if s < 0.0 {
-            self.cursor.set(s + self.frames.len() as f64);
-        } else {
-            self.cursor.set(s);
-        }
+            .rem_euclid(self.frames.len() as f64);
+        self.cursor.set(s);
     }
 }
 

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -37,7 +37,7 @@ impl<T: Frame + Copy> Signal for Cycle<T> {
             } else if x < self.frames.len() {
                 (self.frames[x], self.frames[0])
             } else {
-                offset = (x - self.frames.len()) as f32;
+                offset = (x - self.frames.len()) as f32 + fract;
                 base = 0;
                 let x = unsafe { offset.to_int_unchecked::<usize>() };
                 (self.frames[x], self.frames[x + 1])
@@ -83,5 +83,24 @@ mod tests {
         s.sample(1.0, &mut buf[..2]);
         s.sample(1.0, &mut buf[2..]);
         assert_eq!(buf, [1.0, 2.0, 3.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn wrap_fract() {
+        let s = Cycle::new(Frames::from_slice(1, FRAMES));
+        let mut buf = [0.0; 8];
+        s.sample(0.5, &mut buf[..2]);
+        s.sample(0.5, &mut buf[2..]);
+        assert_eq!(buf, [1.0, 1.5, 2.0, 2.5, 3.0, 2.0, 1.0, 1.5]);
+    }
+
+    #[test]
+    fn wrap_fract_offset() {
+        let s = Cycle::new(Frames::from_slice(1, FRAMES));
+        s.seek(0.25);
+        let mut buf = [0.0; 7];
+        s.sample(0.5, &mut buf[..2]);
+        s.sample(0.5, &mut buf[2..]);
+        assert_eq!(buf, [1.25, 1.75, 2.25, 2.75, 2.5, 1.5, 1.25]);
     }
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -12,6 +12,7 @@ pub trait Frame {
     fn channels_mut(&mut self) -> &mut [Sample];
 }
 
+#[inline(always)]
 fn map<T: Frame>(x: &T, mut f: impl FnMut(Sample) -> Sample) -> T {
     let mut out = T::ZERO;
     for (&x, o) in x.channels().iter().zip(out.channels_mut()) {
@@ -20,6 +21,7 @@ fn map<T: Frame>(x: &T, mut f: impl FnMut(Sample) -> Sample) -> T {
     out
 }
 
+#[inline(always)]
 fn bimap<T: Frame>(x: &T, y: &T, mut f: impl FnMut(Sample, Sample) -> Sample) -> T {
     let mut out = T::ZERO;
     for ((&x, &y), o) in x
@@ -33,14 +35,17 @@ fn bimap<T: Frame>(x: &T, y: &T, mut f: impl FnMut(Sample, Sample) -> Sample) ->
     out
 }
 
+#[inline(always)]
 pub(crate) fn lerp<T: Frame>(a: &T, b: &T, t: f32) -> T {
     bimap(a, b, |a, b| a + t * (b - a))
 }
 
+#[inline(always)]
 pub(crate) fn mix<T: Frame>(a: &T, b: &T) -> T {
     bimap(a, b, |a, b| a + b)
 }
 
+#[inline(always)]
 pub(crate) fn scale<T: Frame>(x: &T, factor: f32) -> T {
     map(x, |x| x * factor)
 }
@@ -48,10 +53,12 @@ pub(crate) fn scale<T: Frame>(x: &T, factor: f32) -> T {
 impl Frame for Sample {
     const ZERO: Sample = 0.0;
 
+    #[inline(always)]
     fn channels(&self) -> &[Sample] {
         core::slice::from_ref(self)
     }
 
+    #[inline(always)]
     fn channels_mut(&mut self) -> &mut [Sample] {
         core::slice::from_mut(self)
     }
@@ -60,10 +67,12 @@ impl Frame for Sample {
 impl<const N: usize> Frame for [Sample; N] {
     const ZERO: Self = [0.0; N];
 
+    #[inline(always)]
     fn channels(&self) -> &[Sample] {
         self.as_ref()
     }
 
+    #[inline(always)]
     fn channels_mut(&mut self) -> &mut [Sample] {
         self.as_mut()
     }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -12,7 +12,7 @@ pub trait Frame {
     fn channels_mut(&mut self) -> &mut [Sample];
 }
 
-#[inline(always)]
+#[inline]
 fn map<T: Frame>(x: &T, mut f: impl FnMut(Sample) -> Sample) -> T {
     let mut out = T::ZERO;
     for (&x, o) in x.channels().iter().zip(out.channels_mut()) {
@@ -21,7 +21,7 @@ fn map<T: Frame>(x: &T, mut f: impl FnMut(Sample) -> Sample) -> T {
     out
 }
 
-#[inline(always)]
+#[inline]
 fn bimap<T: Frame>(x: &T, y: &T, mut f: impl FnMut(Sample, Sample) -> Sample) -> T {
     let mut out = T::ZERO;
     for ((&x, &y), o) in x
@@ -35,17 +35,17 @@ fn bimap<T: Frame>(x: &T, y: &T, mut f: impl FnMut(Sample, Sample) -> Sample) ->
     out
 }
 
-#[inline(always)]
+#[inline]
 pub(crate) fn lerp<T: Frame>(a: &T, b: &T, t: f32) -> T {
     bimap(a, b, |a, b| a + t * (b - a))
 }
 
-#[inline(always)]
+#[inline]
 pub(crate) fn mix<T: Frame>(a: &T, b: &T) -> T {
     bimap(a, b, |a, b| a + b)
 }
 
-#[inline(always)]
+#[inline]
 pub(crate) fn scale<T: Frame>(x: &T, factor: f32) -> T {
     map(x, |x| x * factor)
 }
@@ -53,12 +53,12 @@ pub(crate) fn scale<T: Frame>(x: &T, factor: f32) -> T {
 impl Frame for Sample {
     const ZERO: Sample = 0.0;
 
-    #[inline(always)]
+    #[inline]
     fn channels(&self) -> &[Sample] {
         core::slice::from_ref(self)
     }
 
-    #[inline(always)]
+    #[inline]
     fn channels_mut(&mut self) -> &mut [Sample] {
         core::slice::from_mut(self)
     }
@@ -67,12 +67,12 @@ impl Frame for Sample {
 impl<const N: usize> Frame for [Sample; N] {
     const ZERO: Self = [0.0; N];
 
-    #[inline(always)]
+    #[inline]
     fn channels(&self) -> &[Sample] {
         self.as_ref()
     }
 
-    #[inline(always)]
+    #[inline]
     fn channels_mut(&mut self) -> &mut [Sample] {
         self.as_mut()
     }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -175,9 +175,9 @@ impl<T: Frame + Copy> Signal for FramesSignal<T> {
         let base = s0.trunc() as isize;
         let mut offset = s0.fract() as f32;
         for o in out.iter_mut() {
-            let trunc = offset.trunc();
-            let (a, b) = self.data.get_pair(base + trunc as isize);
-            let fract = offset - trunc;
+            let trunc = unsafe { offset.to_int_unchecked::<isize>() };
+            let (a, b) = self.data.get_pair(base + trunc);
+            let fract = offset - trunc as f32;
             *o = frame::lerp(&a, &b, fract);
             offset += ds;
         }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -93,7 +93,7 @@ impl<T> Frames<T> {
     ///
     /// Note that `s` is in samples, not seconds. Whole numbers are always an exact sample, and
     /// out-of-range positions yield 0.
-    #[inline(always)]
+    #[inline]
     pub fn interpolate(&self, s: f64) -> T
     where
         T: Frame + Copy,
@@ -104,7 +104,7 @@ impl<T> Frames<T> {
         frame::lerp(&a, &b, fract)
     }
 
-    #[inline(always)]
+    #[inline]
     fn get_pair(&self, sample: isize) -> (T, T)
     where
         T: Frame + Copy,

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -173,7 +173,7 @@ impl<T: Frame + Copy> Signal for FramesSignal<T> {
         let s0 = self.t.get() * self.data.rate;
         let ds = interval * self.data.rate as f32;
         let base = s0 as isize;
-        let mut offset = s0.fract() as f32;
+        let mut offset = (s0 - base as f64) as f32;
         for o in out.iter_mut() {
             let trunc = unsafe { offset.to_int_unchecked::<isize>() };
             let (a, b) = self.data.get_pair(base + trunc);

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -118,12 +118,10 @@ impl<T> Frames<T> {
             } else {
                 (T::ZERO, T::ZERO)
             }
+        } else if sample < -1 {
+            (T::ZERO, T::ZERO)
         } else {
-            if sample < -1 {
-                (T::ZERO, T::ZERO)
-            } else {
-                (T::ZERO, self.samples[0])
-            }
+            (T::ZERO, self.samples[0])
         }
     }
 }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -93,6 +93,7 @@ impl<T> Frames<T> {
     ///
     /// Note that `s` is in samples, not seconds. Whole numbers are always an exact sample, and
     /// out-of-range positions yield 0.
+    #[inline(always)]
     pub fn interpolate(&self, s: f64) -> T
     where
         T: Frame + Copy,
@@ -105,6 +106,7 @@ impl<T> Frames<T> {
         frame::lerp(&a, &b, fract)
     }
 
+    #[inline(always)]
     fn get(&self, sample: isize) -> T
     where
         T: Frame + Copy,

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -98,8 +98,8 @@ impl<T> Frames<T> {
     where
         T: Frame + Copy,
     {
-        let x0 = s.trunc() as isize;
-        let fract = s.fract() as f32;
+        let x0 = s as isize;
+        let fract = (s - x0 as f64) as f32;
         let (a, b) = self.get_pair(x0);
         frame::lerp(&a, &b, fract)
     }
@@ -172,7 +172,7 @@ impl<T: Frame + Copy> Signal for FramesSignal<T> {
     fn sample(&self, interval: f32, out: &mut [T]) {
         let s0 = self.t.get() * self.data.rate;
         let ds = interval * self.data.rate as f32;
-        let base = s0.trunc() as isize;
+        let base = s0 as isize;
         let mut offset = s0.fract() as f32;
         for o in out.iter_mut() {
             let trunc = unsafe { offset.to_int_unchecked::<isize>() };

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -100,25 +100,31 @@ impl<T> Frames<T> {
     {
         let x0 = s.trunc() as isize;
         let fract = s.fract() as f32;
-        let x1 = x0 + 1;
-        let a = self.get(x0);
-        let b = self.get(x1);
+        let (a, b) = self.get_pair(x0);
         frame::lerp(&a, &b, fract)
     }
 
     #[inline(always)]
-    fn get(&self, sample: isize) -> T
+    fn get_pair(&self, sample: isize) -> (T, T)
     where
         T: Frame + Copy,
     {
-        if sample < 0 {
-            return T::ZERO;
+        if sample >= 0 {
+            let sample = sample as usize;
+            if sample < self.samples.len() - 1 {
+                (self.samples[sample], self.samples[sample + 1])
+            } else if sample < self.samples.len() {
+                (self.samples[sample], T::ZERO)
+            } else {
+                (T::ZERO, T::ZERO)
+            }
+        } else {
+            if sample < -1 {
+                (T::ZERO, T::ZERO)
+            } else {
+                (T::ZERO, self.samples[0])
+            }
         }
-        let sample = sample as usize;
-        if sample >= self.samples.len() {
-            return T::ZERO;
-        }
-        self.samples[sample]
     }
 }
 

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -93,6 +93,15 @@ where
         if gain.target() != &shared {
             gain.set(shared);
         }
+        if gain.progress() == 1.0 {
+            let g = gain.get();
+            if g != 1.0 {
+                for x in out {
+                    *x = frame::scale(x, g);
+                }
+            }
+            return;
+        }
         for x in out {
             *x = frame::scale(x, gain.get());
             gain.advance(interval / SMOOTHING_PERIOD);

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -96,6 +96,12 @@ mod tests {
         }
     }
 
+    fn assert_out(r: &Ring, rate: u32, t: f32, interval: f32, expected: &[f32]) {
+        let mut output = vec![0.0; expected.len()];
+        r.sample(rate, t, interval, &mut output);
+        assert_eq!(&output, expected);
+    }
+
     #[test]
     fn fill() {
         let mut r = Ring::new(4);
@@ -109,13 +115,8 @@ mod tests {
         assert_eq!(r.write, 3.0);
         assert_eq!(r.buffer[..], [1.0, 2.0, 3.0, 0.0]);
 
-        let mut out1 = [0.0f32; 2];
-        r.sample(1, -1.5, 1.0, &mut out1);
-        assert_eq!(out1, [2.5, 1.5]);
-
-        let mut out2 = [0.0f32; 4];
-        r.sample(1, -1.5, 0.25, &mut out2);
-        assert_eq!(out2, [2.5, 2.75, 3.0, 2.25]);
+        assert_out(&r, 1, -1.5, 1.0, &[2.5, 1.5]);
+        assert_out(&r, 1, -1.5, 0.25, &[2.5, 2.75, 3.0, 2.25]);
     }
 
     #[test]
@@ -129,8 +130,6 @@ mod tests {
         r.write(&s, 1, 3.0);
         assert_eq!(r.buffer[..], [5.0, 6.0, 3.0, 4.0]);
 
-        let mut out = [0.0f32; 6];
-        r.sample(1, -2.75, 0.5, &mut out);
-        assert_eq!(out, [4.25, 4.75, 5.25, 5.75, 5.25, 3.75]);
+        assert_out(&r, 1, -2.75, 0.5, &[4.25, 4.75, 5.25, 5.75, 5.25, 3.75]);
     }
 }


### PR DESCRIPTION
This is mostly the continuation of https://github.com/Ralith/oddio/pull/89

Four changes:
1. The most important one: do not call `Ring::sample` for every sample, process in chunks like the `Spatial::play` already does. Easily gives 50-60% perf improvement.
2. Specialize `FramesSignal::sample` for cases when the the delta is integer (i.e. interval / rate == 1.0), 10% perf improvement.
3. Do not re-initialize scratch buffer for every signal, perf improvement depends on the number of mixed signals.
4. (Not particularly related to the current PR, but I did not want to open a tiny PR just for it): fast-path for `Gain::sample` when the gain is constant.