### PR TITLE
 SpatialScene::play_buffered optimizations

### DIFF
--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -57,12 +57,8 @@ impl<T: Frame + Copy> Signal for Cycle<T> {
 impl<T: Frame + Copy> Seek for Cycle<T> {
     fn seek(&self, seconds: f32) {
         let s = (self.cursor.get() + f64::from(seconds) * self.frames.rate() as f64)
-            % self.frames.len() as f64;
-        if s < 0.0 {
-            self.cursor.set(s + self.frames.len() as f64);
-        } else {
-            self.cursor.set(s);
-        }
+            .rem_euclid(self.frames.len() as f64);
+        self.cursor.set(s);
     }
 }
 

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -93,6 +93,15 @@ where
         if gain.target() != &shared {
             gain.set(shared);
         }
+        if gain.progress() == 1.0 {
+            let g = gain.get();
+            if g != 1.0 {
+                for x in out {
+                    *x = frame::scale(x, g);
+                }
+            }
+            return;
+        }
         for x in out {
             *x = frame::scale(x, gain.get());
             gain.advance(interval / SMOOTHING_PERIOD);

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -96,6 +96,12 @@ mod tests {
         }
     }
 
+    fn assert_out(r: &Ring, rate: u32, t: f32, interval: f32, expected: &[f32]) {
+        let mut output = vec![0.0; expected.len()];
+        r.sample(rate, t, interval, &mut output);
+        assert_eq!(&output, expected);
+    }
+
     #[test]
     fn fill() {
         let mut r = Ring::new(4);
@@ -109,13 +115,8 @@ mod tests {
         assert_eq!(r.write, 3.0);
         assert_eq!(r.buffer[..], [1.0, 2.0, 3.0, 0.0]);
 
-        let mut out1 = [0.0f32; 2];
-        r.sample(1, -1.5, 1.0, &mut out1);
-        assert_eq!(out1, [2.5, 1.5]);
-
-        let mut out2 = [0.0f32; 4];
-        r.sample(1, -1.5, 0.25, &mut out2);
-        assert_eq!(out2, [2.5, 2.75, 3.0, 2.25]);
+        assert_out(&r, 1, -1.5, 1.0, &[2.5, 1.5]);
+        assert_out(&r, 1, -1.5, 0.25, &[2.5, 2.75, 3.0, 2.25]);
     }
 
     #[test]
@@ -129,8 +130,6 @@ mod tests {
         r.write(&s, 1, 3.0);
         assert_eq!(r.buffer[..], [5.0, 6.0, 3.0, 4.0]);
 
-        let mut out = [0.0f32; 6];
-        r.sample(1, -2.75, 0.5, &mut out);
-        assert_eq!(out, [4.25, 4.75, 5.25, 5.75, 5.25, 3.75]);
+        assert_out(&r, 1, -2.75, 0.5, &[4.25, 4.75, 5.25, 5.75, 5.25, 3.75]);
     }
 }

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -63,8 +63,8 @@ impl Ring {
                 (self.buffer[x], self.buffer[0])
             } else {
                 base = 0;
-                offset = (x % self.buffer.len()) as f32 + fract;
-                let x = unsafe { offset.to_int_unchecked::<usize>() };
+                let x = x % self.buffer.len();
+                offset = x as f32 + fract;
                 if x < self.buffer.len() - 1 {
                     (self.buffer[x], self.buffer[x + 1])
                 } else {

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -49,20 +49,17 @@ impl Ring {
             ((t * rate as f32).abs().ceil() as usize) < self.buffer.len(),
             "samples must lie less than a buffer period in the past"
         );
-        let s0 = (self.write + t * rate as f32).rem_euclid(self.buffer.len() as f32);
+        let mut offset = (self.write + t * rate as f32).rem_euclid(self.buffer.len() as f32);
         let ds = interval * rate as f32;
-        let mut base = s0 as usize;
-        let mut offset = s0 - base as f32;
         for o in out.iter_mut() {
             let trunc = unsafe { offset.to_int_unchecked::<usize>() };
             let fract = offset - trunc as f32;
-            let x = base + trunc;
+            let x = trunc;
             let (a, b) = if x < self.buffer.len() - 1 {
                 (self.buffer[x], self.buffer[x + 1])
             } else if x < self.buffer.len() {
                 (self.buffer[x], self.buffer[0])
             } else {
-                base = 0;
                 let x = x % self.buffer.len();
                 offset = x as f32 + fract;
                 if x < self.buffer.len() - 1 {


### PR DESCRIPTION
Replacing #92

This is mostly the continuation of https://github.com/Ralith/oddio/pull/89

Four changes:

1. The most important one: do not call Ring::sample for every sample, process in chunks like the Spatial::play already does. Easily gives 50-60% perf improvement.
2. Specialize FramesSignal::sample for cases when the the delta is integer (i.e. interval / rate == 1.0), 10% perf improvement.
3. Do not re-initialize scratch buffer for every signal, perf improvement depends on the number of mixed signals.
4. (Not particularly related to the current PR, but I did not want to open a tiny PR just for it): fast-path for Gain::sample when the gain is constant.